### PR TITLE
Update documentation: PyPI instructions + implementation details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,16 @@ We follow the [Buck2 coding conventions](https://github.com/facebook/buck2/blob/
 
 ## Testing
 
-You can use `cargo test` to run the tests, or `python3 test.py` from this directory.
+Run `cargo test` from this directory. To match the GitHub CI checks, run:
+
+```bash
+cargo fmt -- --check
+cargo clippy --release
+cargo test --release
+cargo build --bin lifeguard --release
+```
+
+`test.py` is an internal script that depends on `arc` and `buck2`.
 
 Tests live in `tests/`, and the harness is `src/test_lib.rs`. Most tests are a
 `#[test]` function holding inline Python, where the expected results are written

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,16 +35,7 @@ We follow the [Buck2 coding conventions](https://github.com/facebook/buck2/blob/
 
 ## Testing
 
-Run `cargo test` from this directory. To match the GitHub CI checks, run:
-
-```bash
-cargo fmt -- --check
-cargo clippy --release
-cargo test --release
-cargo build --bin lifeguard --release
-```
-
-`test.py` is an internal script that depends on `arc` and `buck2`.
+You can use `cargo test` to run the tests, or `python3 test.py` from this directory.
 
 Tests live in `tests/`, and the harness is `src/test_lib.rs`. Most tests are a
 `#[test]` function holding inline Python, where the expected results are written

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -2,9 +2,21 @@
 
 Lifeguard analyzes Python codebases to determine which modules can safely
 use lazy imports without triggering side effects at import time. This guide
-walks you through building and running the tool from source using Cargo.
+walks you through installing the tool from PyPI or building it from source.
 
-## Prerequisites
+## Install from PyPI
+
+```bash
+pip install lifeguard-lazy-imports
+lifeguard run-tree /path/to/project output.json --verbose-output verbose.txt
+```
+
+Wheels are available for Linux, macOS, and Windows on Python 3.12 or newer, so
+no Rust toolchain is needed. `python -m lifeguard_lazy_imports` is equivalent
+to the `lifeguard` command. In the Cargo examples below, substitute `lifeguard`
+for `cargo run --`; the bundled sample project is in the repository, not the package.
+
+## Prerequisites for Building from Source
 
 - **Rust (nightly)** — the crate uses unstable features, so you need a nightly
   toolchain. Install via [rustup](https://rustup.rs/) and set it with

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -18,9 +18,8 @@ for `cargo run --`; the bundled sample project is in the repository, not the pac
 
 ## Prerequisites for Building from Source
 
-- **Rust (nightly)** — the crate uses unstable features, so you need a nightly
-  toolchain. Install via [rustup](https://rustup.rs/) and set it with
-  `rustup default nightly`.
+- **Rust (nightly)** — install via [rustup](https://rustup.rs/). Cargo selects
+  the nightly pinned in [rust-toolchain.toml](rust-toolchain.toml) automatically.
 - **Git** — needed to clone Lifeguard and its submodules.
 
 ## Clone & Setup
@@ -46,7 +45,9 @@ cargo build
 
 ## Quick Start — Analyze a directory (`run-tree`)
 
-The `run-tree` subcommand analyzes every `.py` file under a directory tree.
+The `run-tree` subcommand discovers `.py` files under a directory tree and
+follows resolvable top-level imports. File and directory names below the input
+root must be ASCII Python identifiers; other paths are skipped.
 
 Run it against the bundled sample project:
 
@@ -76,7 +77,6 @@ Num of passing files: 3
 Num of load-imports-eagerly modules: 2
 Output written to output.json
 Full time executing: 222.72ms
-Full time executing (CPU): 1.39s
 ```
 
 **Reading the output:**
@@ -87,7 +87,8 @@ Full time executing (CPU): 1.39s
 | Failing files | Modules with side effects that prevent lazy imports |
 | Load-imports-eagerly modules | Modules where *all* imports must be loaded eagerly (e.g. `exec()` calls, custom `__del__` finalizers) |
 
-The JSON written to `output.json` contains two top-level keys:
+The JSON written to `output.json` contains these keys (the last two only with
+`--verbose-output`):
 
 ```json
 {
@@ -97,16 +98,18 @@ The JSON written to `output.json` contains two top-level keys:
   ],
   "LAZY_ELIGIBLE": {
     "importer": [
-      "safer_lazy_imports.lifeguard.testdata.sample_project.unsafe_module.helper",
       "safer_lazy_imports.lifeguard.testdata.sample_project.safe_module",
       "safer_lazy_imports.lifeguard.testdata.sample_project.safe_module.greet",
-      "safer_lazy_imports.lifeguard.testdata.sample_project.unsafe_module"
+      "safer_lazy_imports.lifeguard.testdata.sample_project.unsafe_module",
+      "safer_lazy_imports.lifeguard.testdata.sample_project.unsafe_module.helper"
     ],
+    "pkg": [],
+    "pkg.sub": [],
     "safe_module": [],
-    "unsafe_module": [
-      "os.path"
-    ]
-  }
+    "unsafe_module": []
+  },
+  "IMPLICIT_IMPORTS": {},
+  "IMPORT_CYCLES": []
 }
 ```
 
@@ -118,11 +121,13 @@ The JSON written to `output.json` contains two top-level keys:
   dependencies that must be imported eagerly when that module is loaded lazily.
   - An empty list (like `safe_module` above) means the module is fully safe
     with no caveats.
-  - A non-empty list (like `unsafe_module` → `["os.path"]`) means the module
+  - A non-empty list (like `importer` above) means the module
     is safe *except* those dependencies must be loaded eagerly.
-  - Modules that appear in `LOAD_IMPORTS_EAGERLY` are omitted from this dict.
+  - A module can appear in both `LAZY_ELIGIBLE` and `LOAD_IMPORTS_EAGERLY`.
+- **`IMPLICIT_IMPORTS`** and **`IMPORT_CYCLES`** — diagnostic details included
+  only with `--verbose-output`. Both are empty in this sample run.
 
-# Reading the verbose output
+## Reading the verbose output
 
 When you pass `--verbose-output verbose.txt`, Lifeguard writes a per-module
 breakdown. Here is an example:
@@ -132,52 +137,58 @@ breakdown. Here is an example:
 ------------------------------------------------------------------------------
 ## has_finalizer
 ### Errors
-  Line 6 - CustomFinalizer __del__
+CustomFinalizer (1)
+  Line 11 - __del__
+
 ### Load Imports Eagerly
-  Line 6 - CustomFinalizer __del__
-### Implicit Imports
+CustomFinalizer (1)
+  Line 11 - __del__
 
 ## importer
 ### Lazy imports incompatibilities were not detected
 
 ## main
 ### Errors
-  Line 10 - UnsafeFunctionCall main.main
-### Load Imports Eagerly
-### Implicit Imports
+UnsafeFunctionCall (1)
+  Line 21 - main.main
 
 ## safe_module
 ### Lazy imports incompatibilities were not detected
 
 ## unsafe_module
-### Errors
-### Load Imports Eagerly
-### Implicit Imports
-  os.path
+### Lazy imports incompatibilities were not detected
 
 ## uses_exec
 ### Errors
-  Line 3 - ExecCall exec
+ExecCall (1)
+  Line 8 - exec
+
 ### Load Imports Eagerly
-  Line 3 - ExecCall exec
-### Implicit Imports
+ExecCall (1)
+  Line 8 - exec
 ```
 
 Each `##` heading is a module. Under it you will see:
 
-- **"Lazy imports incompatibilities were not detected"** — the module is fully
-  safe; nothing else to report.
-- **Errors** — side effects detected at the listed lines. The format is
-  `Line <n> - <ErrorKind> <detail>`. Common error kinds:
-  - `CalledImport` — an imported function is called at module scope
-  - `UnsafeFunctionCall` — a local function with side effects is called at
-    module scope
+- **"Lazy imports incompatibilities were not detected"** — no local safety
+  errors, eager-import overrides, or implicit imports were reported. The JSON
+  can still list dependency constraints, as it does for `importer` above.
+- **Errors** — diagnostics grouped under `<ErrorKind> (<count>)`, followed by
+  `Line <n> - <detail>` entries. Common error kinds:
+  - `UnknownFunctionCall` — a call target could not be resolved
+  - `UnsafeFunctionCall` — a local or imported function was not determined safe
+    to call eagerly
   - `CustomFinalizer` — a class defines `__del__`
   - `ExecCall` — the module calls `exec()`
 - **Load Imports Eagerly** — errors that cause the module to be added to the
-  `LOAD_IMPORTS_EAGERLY` set (lazy imports fully disabled for this module).
-- **Implicit Imports** — modules that are implicitly imported as a side effect
-  of importing this module (e.g. `import os.path` implicitly imports `os`).
+  `LOAD_IMPORTS_EAGERLY` set (its own imports must execute eagerly).
+- **Implicit Imports** — submodule accesses that rely on another import having
+  already loaded the submodule, such as `import foo; foo.bar` without a direct
+  import of `foo.bar`. See [docs/implicit_imports.md](docs/implicit_imports.md).
+- **Analysis Error** — the module could not be analyzed, for example because
+  parsing failed.
+
+Empty diagnostic sections are omitted.
 
 ## Running tests
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -176,8 +176,7 @@ Each `##` heading is a module. Under it you will see:
 - **Errors** — diagnostics grouped under `<ErrorKind> (<count>)`, followed by
   `Line <n> - <detail>` entries. Common error kinds:
   - `UnknownFunctionCall` — a call target could not be resolved
-  - `UnsafeFunctionCall` — a local or imported function was not determined safe
-    to call eagerly
+  - `UnsafeFunctionCall` — a local or imported function that was statically analyzed to be lazy imports incompatible
   - `CustomFinalizer` — a class defines `__del__`
   - `ExecCall` — the module calls `exec()`
 - **Load Imports Eagerly** — errors that cause the module to be added to the

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -187,8 +187,6 @@ Each `##` heading is a module. Under it you will see:
 - **Analysis Error** — the module could not be analyzed, for example because
   parsing failed.
 
-Empty diagnostic sections are omitted.
-
 ## Running tests
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ lifeguard run-tree /path/to/project output.json --verbose-output verbose.txt
 ```
 
 `python -m lifeguard_lazy_imports` is equivalent to the `lifeguard` command. The `cargo run --` examples below build and run the tool from source; with the installed package, replace `cargo run --` with `lifeguard`.
+PyPI releases are cut manually and can lag behind the main branch. Run `lifeguard --help` to see what your installed version supports.
 
 ## Prerequisites for Building from Source
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,18 @@ Lifeguard is in active development. We are aiming to be ready for general use by
 - We are actively developing a standalone linter output mode to help users identify which specific lines in their codebase are incompatible with Lazy Imports.
 - We plan to add support for easy ingestion of Lifeguard's output to drive Lazy Imports enablement for advanced users (see [Using the Output](#using-the-output)).
 
-## Prerequisites
+## Install from PyPI
+
+Lifeguard is published on [PyPI](https://pypi.org/project/lifeguard-lazy-imports/) with prebuilt wheels for Linux, macOS, and Windows (x86-64 and ARM64). It requires Python 3.12 or newer and no Rust toolchain:
+
+```bash
+pip install lifeguard-lazy-imports
+lifeguard run-tree /path/to/project output.json --verbose-output verbose.txt
+```
+
+`python -m lifeguard_lazy_imports` is equivalent to the `lifeguard` command. The `cargo run --` examples below build and run the tool from source; with the installed package, replace `cargo run --` with `lifeguard`.
+
+## Prerequisites for Building from Source
 
 - **Rust (nightly)** — the crate uses unstable features. Install via [rustup](https://rustup.rs/) and set with `rustup default nightly`.
 - **Git** — clone with submodules: `git clone --recurse-submodules https://github.com/facebook/Lifeguard.git`

--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ For a deeper look at the analysis pipeline and architecture, see [docs/architect
 Lifeguard is in active development. We are aiming to be ready for general use by the [Python 3.15 final release](https://peps.python.org/pep-0790/).
 
 ### Items on our roadmap
-- We are preparing GitHub actions to fully support external contributors.
-- We've tested and support Python 3.12 and 3.14. Other versions may also work. We do not yet support the [`lazy` keyword added in PEP 810](https://peps.python.org/pep-0810/) — but we fully intend to support this ahead of the 3.15 release.
+- We've tested and support Python 3.12 and 3.14. Other versions may also work. To analyze the explicit `lazy import` syntax from [PEP 810](https://peps.python.org/pep-0810/), pass `--python-version 3.15`.
 - We are actively developing a standalone linter output mode to help users identify which specific lines in their codebase are incompatible with Lazy Imports.
 - We plan to add support for easy ingestion of Lifeguard's output to drive Lazy Imports enablement for advanced users (see [Using the Output](#using-the-output)).
 
@@ -53,14 +52,14 @@ lifeguard run-tree /path/to/project output.json --verbose-output verbose.txt
 
 ## Prerequisites for Building from Source
 
-- **Rust (nightly)** — the crate uses unstable features. Install via [rustup](https://rustup.rs/) and set with `rustup default nightly`.
+- **Rust (nightly)** — install via [rustup](https://rustup.rs/). Cargo uses the nightly pinned in [rust-toolchain.toml](rust-toolchain.toml); there is no need to change your global default toolchain.
 - **Git** — clone with submodules: `git clone --recurse-submodules https://github.com/facebook/Lifeguard.git`
 
 If you already cloned without `--recurse-submodules`, run `git submodule update --init --recursive`.
 
 ## Quick Start
 
-The fastest way to try Lifeguard is the `run-tree` subcommand, which analyzes every `.py` file under a directory. No additional setup needed.
+The fastest way to try Lifeguard is the `run-tree` subcommand, which discovers `.py` files under a directory and follows resolvable top-level imports. File and directory names below the input root must be ASCII Python identifiers; other paths are skipped.
 
 ```bash
 cargo run -- run-tree <INPUT_DIR> <OUTPUT_PATH>
@@ -90,9 +89,9 @@ Optionally, if your project has library dependencies, you can point Lifeguard at
 site_packages = "/path/to/site-packages"
 ```
 
-You can find out your site-packages path via `python -m site`. The `gen-source-db` subcommand reads this section automatically when generating the source DB.
+You can find out your site-packages path via `python -m site`. Both `gen-source-db` and `run-tree` read this section from `<INPUT_DIR>/pyproject.toml`. Relative `site_packages` paths are resolved against `INPUT_DIR`. You can override the setting with `--site-packages /path/to/site-packages`.
 
-**Note:** The script may not discover all of your project's dependencies. If Lifeguard reports missing modules, you may need to manually add entries to the generated source DB.
+**Note:** Discovery follows top-level import statements and may not discover all dependencies, such as imports nested in functions or conditional blocks outside the input tree. If Lifeguard reports missing modules, you may need to manually add entries to the generated source DB. For explicit lazy syntax, pass `--python-version 3.15` to both source discovery and analysis.
 
 2. Run Lifeguard in one of two modes:
    - **Default**: Prints a high-level analysis of your codebase (% of compatible files, top errors, etc.) and writes the JSON output to `OUTPUT_PATH`.
@@ -108,8 +107,11 @@ You can find out your site-packages path via `python -m site`. The `gen-source-d
 ```text
 ## example.module.foo
 ### Errors
-  Line 17 - ImportedModuleAssignment sys
-  Line 38 - UnsafeFunctionCall example.demo.unsafe_method
+ImportedModuleAssignment (1)
+  Line 17 - sys
+
+UnsafeFunctionCall (1)
+  Line 38 - example.demo.unsafe_method
 ```
 
 ## Input Format
@@ -136,11 +138,13 @@ Lifeguard writes a JSON file with two fields:
     "LAZY_ELIGIBLE": {
         "module1": [],
         "module2": ["module3", "module4"],
-        "module5": [],
+        "module5": []
     },
     "LOAD_IMPORTS_EAGERLY": ["module5", "module99", "module100"]
 }
 ```
+
+With `--verbose-output`, the JSON also includes `IMPLICIT_IMPORTS` (a module-to-dependencies mapping) and `IMPORT_CYCLES` (lists of modules in each cycle). Use `--sorted-output` for deterministic ordering of these fields.
 
 ### `LAZY_ELIGIBLE`
 
@@ -170,7 +174,7 @@ Lifeguard can be used as a standalone linter to identify which specific lines in
 
 ### To drive a lazy import loader
 
-The JSON output is designed to drive a lazy import loader's filter function. In Python 3.15, [`importlib.util.lazy_import`](https://peps.python.org/pep-0810/) accepts a filter callback that controls which imports are deferred and which are loaded eagerly. Lifeguard's output provides the data needed to build this filter — using `LAZY_ELIGIBLE` to identify safe modules and their constraints, and `LOAD_IMPORTS_EAGERLY` to identify modules that need all imports resolved upfront.
+The JSON output is designed to drive a lazy import loader's filter function. In Python 3.15, [`sys.set_lazy_imports_filter()`](https://peps.python.org/pep-0810/#lazy-imports-filter) installs a callback that controls which imports are deferred and which are loaded eagerly. Lifeguard's output provides the data needed to build this filter — using `LAZY_ELIGIBLE` to identify safe modules and their constraints, and `LOAD_IMPORTS_EAGERLY` to identify modules that need all imports resolved upfront.
 
 We plan to provide tooling for easy ingestion of Lifeguard's output ahead of the Python 3.15 release. This is a work in progress.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ when they disagree on more modules than `--max-divergent-modules` allows.
 - `mro.rs` - C3 linearization, so an inherited method resolves to the same definition CPython would pick
 
 **Pipeline orchestration**:
-- `runner.rs` - Shared pipeline orchestration used by `main.rs` and `commands/run_tree.rs`
+- `runner.rs` - Shared pipeline orchestration used by the analysis subcommands
 
 **AST traversal helpers**:
 - `cursor.rs` - Tracks current scope during AST traversal (module → class → function)
@@ -83,7 +83,7 @@ when they disagree on more modules than `--max-divergent-modules` allows.
 - `manual_override.rs` - Hardcoded list of functions declared safe (`SAFE_FUNCTIONS_ARRAY`)
 - `module_parser.rs` - Module parsing abstraction
 - `config.rs` - Analysis configuration (`AnalysisConfig`)
-- `hasher.rs` - Fixed-seed hashing, so the analyzer's many small maps produce deterministic output
+- `hasher.rs` - Fixed-seed hashing, avoiding per-map seed generation for the analyzer's many small maps
 - `tracing.rs` - Simple timing utility
 - `debug.rs` - Dump helpers for exports, import cycles, and the module imports map
 - `traits.rs` - Extension traits bridging lifeguard with pyrefly types
@@ -108,9 +108,9 @@ These are critical design decisions affecting correctness:
 
 - **Indexing imported objects**: Treated as SAFE (most don't override `__getitem__` unsafely)
 - **Recursive function calls**: Treated as UNSAFE (cannot determine termination)
-- **Unresolved function calls**: Treated as SAFE (most are builtins)
+- **Unresolved function calls**: Treated as UNSAFE when reached from eager code (reported as `UnknownFunctionCall`)
 - **`exec()` calls**: Module marked as UNSAFE and added to load_imports_eagerly set (differs from original analyzer)
-- **`sys.modules` access**: Module added to load_imports_eagerly set (subscript access and method calls depend on import ordering that lazy imports disrupts)
+- **`sys.modules` access**: Module added to load_imports_eagerly set (subscript access and method calls depend on import ordering that lazy imports disrupts). Some subscript reads are exempted; see [load_imports_eagerly.md](load_imports_eagerly.md).
 
 ### Output Structure
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,11 @@ when they disagree on more modules than `--max-divergent-modules` allows.
 - `output.rs` - `LifeGuardOutput` and `LifeGuardAnalysis` construction
 
 **Incremental analysis**:
-- `cache.rs` - Per-library cache model (`LibraryCache`, `CachedModule`, `CachedExports`)
+- `cache.rs` - Declares the cache submodules and re-exports their types and functions
+- `cache/artifact.rs` - Per-library cache model (`LibraryCache`, `CachedModule`, `CachedExports`) and construction from analysis results
+- `cache/bundled_stubs.rs` - Reconstructs graph-only bundled stub modules omitted from per-library artifacts
+- `cache/merge.rs` - Merges library records and propagates facts independent of final safety resolution
+- `cache/reduce.rs` - Resolves merged caches into final analysis results
 - `cache_wire.rs` - On-disk cache format, read and write
 - `resolution.rs` - Function-safety resolution (`resolve_program`); used by the reduce and by the whole-program path in `project.rs`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,11 +24,9 @@ The pipeline above analyzes a program's whole transitive source DB in one pass. 
 verdicts can also be produced incrementally, so that editing one library does not force a
 re-analysis of everything:
 
-- **Map** — `analyze-library` analyzes a single library against its own sources and writes
-  a binary cache file (`commands/analyze_library.rs`, `cache.rs`, `cache_wire.rs`).
+- **Map** — `analyze-library` analyzes a single library against its own sources and writes a binary cache file.
 - **Reduce** — `analyze-binary` merges the per-library caches, resolves cross-library
-  function safety, and emits the same final output (`commands/analyze_binary.rs`,
-  `resolution.rs`).
+  function safety, and emits the same final output.
 
 The map phase cannot see other libraries, so a call it could not resolve is recorded as a
 candidate rather than a verdict; the reduce phase resolves those against the merged program

--- a/docs/effects_and_errors.md
+++ b/docs/effects_and_errors.md
@@ -14,10 +14,14 @@ pub struct Effect {
     pub name: ModuleName,   // Fully qualified name of the entity involved
     pub range: TextRange,   // Source location (byte range)
     pub data: EffectData,   // Optional metadata (e.g., whether call args are unsafe)
+    pub try_handlers: Option<Box<[TryHandler]>>, // Enclosing handlers at a call site
 }
 ```
 
-`EffectData` is either `None` or `Call(CallData { has_unsafe_args })`, indicating whether any argument to a call is an imported variable.
+`EffectData` is either `None` or `Call(Box<CallData>)`. `CallData` tracks imported
+arguments by positional index and keyword name, uncertainty from `*args` and
+`**kwargs`, and forwarding of the enclosing function's parameters. Its
+`has_unsafe_args()` accessor indicates whether imported arguments are present.
 
 ### EffectKind
 
@@ -25,7 +29,7 @@ pub struct Effect {
 
 ### Key EffectKind Methods
 
-- **`is_runnable()`** — Returns true for call effects where the analyzer can recurse into the called function body: `FunctionCall`, `ImportedFunctionCall`, `DecoratorCall`, `ImportedDecoratorCall`, `MethodCall`. These trigger call graph traversal in `project.rs`.
+- **`is_runnable()`** — Returns true for call effects where the analyzer can recurse into the called function body: `FunctionCall`, `ImportedFunctionCall`, `DecoratorCall`, `ImportedDecoratorCall`, `MethodCall`, `UnboundMethodCall`. These trigger call graph traversal in `project.rs`.
 
 - **`requires_eager_loading_imports()`** — Returns true for `CustomFinalizer`, `ExecCall`, `SysModulesAccess`. These cause the module to be added to the `load_imports_eagerly` set regardless of scope.
 
@@ -45,7 +49,7 @@ The `SourceAnalyzer` walks the Python AST and produces effects for each statemen
 - Function/method calls are resolved and classified (imported, local, unknown)
 - Decorators are treated as function calls
 - Function/class bodies are analyzed in their own scope
-- `raise` statements produce effects unless inside a `try:` block
+- `raise` statements produce effects unless an enclosing handler is recognized as catching the exception; being inside a `try:` block alone is not enough
 - Special builtins (`exec`, `getattr`/`setattr` with non-literal args, `sys.modules`) get dedicated effect kinds
 
 **Stub files (`.pyi`) — `stub_analyzer.rs`:**
@@ -53,10 +57,18 @@ Stubs declare effects explicitly using pseudo-function calls in the body:
 ```python
 def some_function():
     imported_function_call("os.path.join")  # declares this effect
-    mutation()                               # declares this is mutating
-    no_effects()                            # declares this is safe
+
+def mutating_method(self):
+    mutation()  # declares receiver mutation
+
+def safe_function():
+    no_effects()  # declares this is safe
 ```
-Functions with body `...` and no annotations automatically get `UnknownEffects`.
+Functions with no declared effects (for example, a body containing only `...`)
+automatically get `UnknownEffects`, regardless of type annotations. Overloads
+share effects, so an annotated overload can replace those unknown markers.
+Do not combine `no_effects()` with other effect kinds for the same function,
+including across overloads: the stub analyzer rejects the conflict.
 
 ## Errors
 
@@ -69,6 +81,7 @@ pub struct SafetyError {
     pub kind: ErrorKind,
     pub metadata: ErrorMetadata,  // interned string (usually the entity name)
     pub range: TextRange,
+    pub parameterized_decorator: bool,
 }
 ```
 
@@ -124,7 +137,11 @@ The conversion from effects to errors happens in `project.rs` and is the heart o
 
 ### Step 1: Merge Effects
 
-All per-module `EffectTable`s are merged into a single global table (`merge_all_effects`). Nested scope effects are propagated upward — a decorator wrapping a function with side effects is itself marked as having side effects.
+All per-module `EffectTable`s are merged into a single global table
+(`merge_all_effects`). Class-body effects inside a function are propagated to
+that enclosing function. Nested function bodies are not propagated here; the
+call graph handles their execution. Parameterized decorators have additional
+call-site handling for the returned wrapper's effects.
 
 ### Step 2: Build ProjectInfo
 
@@ -144,24 +161,25 @@ All per-module `EffectTable`s are merged into a single global table (`merge_all_
    - `UnknownDecoratorCall` → `UnknownDecoratorCall`
    - `UnknownEffects` → `UnknownEffects`
    - `UnknownObject` → `UnknownObject`
+   - `TooManyArgs` → `TooManyArgs`
 
 2. **Call graph traversal** (`SafetyError::from_unsafe_call`): For "runnable" effects (`FunctionCall`, `MethodCall`, `DecoratorCall`, etc.), the analyzer recursively walks into the called function's body to determine safety. This uses:
    - A `CallStack` to prevent infinite recursion
-   - A `FunctionSafety` cache with three states: `Safe`, `Unsafe`, and `UnsafeIfImported` (safe when called within the same module, unsafe cross-module due to global variable mutation)
+   - Cached `FunctionSafetyInfo` with a `FunctionSafety` bitset: `Safe` is the empty set; `Unsafe`, `UnsafeIfImported` (global mutation unsafe across modules), and `UnsafeMissingDep` (an unresolved transitive callee) are independent concerns that can coexist
 
 3. **Special handling**:
    - `ImportedVarMutation` at module scope → `ImportedModuleAssignment` error
    - `ImportedTypeAttr` → checked for property access, treated as a call
-   - `ImportedVarArgument` + `ParamMethodCall` → `ImportedVarArgument` error
+   - Imported arguments matched to directly or transitively mutated parameters → `ImportedVarArgument` error
    - Effects with `requires_eager_loading_imports()` → added to `force_imports_eager_overrides`
 
 ### Not All Effects Become Errors
 
 Many effect kinds exist only for call graph traversal or state tracking:
 
-- `FunctionCall`, `ImportedFunctionCall`, `MethodCall`, `DecoratorCall`, `ImportedDecoratorCall` — only become errors if the called function is determined unsafe after body analysis
+- `FunctionCall`, `ImportedFunctionCall`, `MethodCall`, `UnboundMethodCall`, `DecoratorCall`, `ImportedDecoratorCall` — checked through call resolution and body analysis; unresolved or unsafe callees can produce errors
 - `GlobalVarAssign`, `GlobalVarMutation` — only become errors in cross-module calls (`UnsafeIfImported`)
-- `ParamMethodCall` — only becomes an error if the call has `has_unsafe_args: true`
+- `ParamMethodCall` — seeds parameter-mutation tracking; calls are flagged when imported arguments reach the affected parameters
 - `ClassVarAssign`, `SetAttr`, `SetSubscript` — tracked as effects but not directly converted to errors
 - `NoEffects`, `Mutation`, `Dunder` — stub-only markers, never directly become errors
 

--- a/docs/implicit_imports.md
+++ b/docs/implicit_imports.md
@@ -36,7 +36,7 @@ During AST traversal of each module (`source_analyzer.rs`), three data structure
 
 - **`pending_imports`**: Maps scopes (module-level or function names) to the set of modules imported in that scope. Every `import X` or `from X import Y` statement adds entries here.
 - **`called_imports`**: Maps scopes to modules that are actually used/accessed (not just imported). When code accesses `foo.bar` and `foo` is a known import, `foo.bar` is recorded as a called import.
-- **`called_functions`**: Tracks which functions defined in the module are actually called at module level. This is used to determine whether a function call triggers an import.
+- **`called_functions`**: Records function calls encountered in the module, including imported functions. This is used to determine whether a function call triggers an import.
 
 ### Phase 2: Cross-Module Detection
 
@@ -61,6 +61,9 @@ A called import is **not** implicit if any of the following hold:
 4. **Attribute of imported parent**: The called import is actually an attribute of an already-imported parent module (not a separate module). This is determined using the import graph to distinguish "module `foo.bar`" from "attribute `bar` on module `foo`".
 
 5. **Import-as alias**: The import resolves through an alias (e.g., `import foo.bar.baz as baz`).
+
+6. **Startup submodule**: The name is in the analyzer's fixed startup set:
+   `encodings.aliases`, `encodings.utf_8`, or `os.path`.
 
 The final result is: `called_imports − non_implicit_imports = implicit_imports`.
 

--- a/docs/load_imports_eagerly.md
+++ b/docs/load_imports_eagerly.md
@@ -38,7 +38,19 @@ exec(config_code)  # Static analysis cannot reason about this
 
 ### 3. sys.modules Access
 
-**Trigger**: A subscript access (`sys.modules["x"]`) or method call (`sys.modules.setdefault(...)`, `sys.modules.pop(...)`) on `sys.modules` anywhere in the module.
+**Trigger**: A subscript access (`sys.modules["x"]`) or method call (`sys.modules.setdefault(...)`, `sys.modules.pop(...)`) on `sys.modules`, subject to the read exceptions below.
+
+For subscript reads with a literal string key, the analyzer suppresses this
+effect when the key names the current module, one of its parent packages, or
+`__main__`, `builtins`, or `sys`. It also suppresses the effect when an enclosing
+`try` handler explicitly names `KeyError`, or the module contains a recognized
+`"key" in sys.modules` / `"key" not in sys.modules` test for that key.
+Membership tests are collected across the module; this is a heuristic, not a
+proof that a test guards a particular read. Aliases such as `import sys as s`
+are not recognized by that membership-test scan.
+
+These exceptions do not apply to subscript writes, deletions, or method calls.
+A bare `except:` or `except Exception:` alone does not exempt a subscript read.
 
 **Why this may be unsafe**: `sys.modules` is a runtime dict that reflects which modules have been loaded. Code that reads or writes `sys.modules` typically depends on other imports having already executed. Under lazy imports, `import foo` is deferred, so a subsequent `sys.modules["foo"]` will raise `KeyError` because the module hasn't actually been loaded yet. To ensure all imports are present in `sys.modules` when the module accesses it, we eagerly load imports in modules that access `sys.modules`.
 

--- a/docs/load_imports_eagerly.md
+++ b/docs/load_imports_eagerly.md
@@ -38,7 +38,7 @@ exec(config_code)  # Static analysis cannot reason about this
 
 ### 3. sys.modules Access
 
-**Trigger**: A subscript access (`sys.modules["x"]`) or method call (`sys.modules.setdefault(...)`, `sys.modules.pop(...)`) on `sys.modules`, subject to the read exceptions below.
+**Trigger**: A subscript access (`sys.modules["x"]`) or method call (`sys.modules.setdefault(...)`, `sys.modules.pop(...)`) on `sys.modules` at any scope, subject to the read exceptions below.
 
 For subscript reads with a literal string key, the analyzer suppresses this
 effect when the key names the current module, one of its parent packages, or

--- a/resources/stubs/stubs.md
+++ b/resources/stubs/stubs.md
@@ -25,3 +25,6 @@ annotations to the first overload in a set, leaving all the other overloads as
 them against the original typeshed files easier. There is a helper script,
 `resources/scripts/normalize_stubs.py`, which will rewrite the stubs to do this
 overload merging if needed.
+
+Use `no_effects()` only for a function with no other declared effects; the stub
+analyzer rejects combining it with other effect kinds, even across overloads.


### PR DESCRIPTION
After the package was published to PyPI it would be great to add instructions how to install and use it without building from source.

Additionally, some docs drifted from the actual implementation. Updating them.

Each commit can be reviewed on its own.

There are only docs changes in this PR, code isn't touched.